### PR TITLE
add custom methods for closing indexer and removing listeners

### DIFF
--- a/lib/headerindexer.js
+++ b/lib/headerindexer.js
@@ -26,6 +26,7 @@ class HeaderIndexer extends Indexer {
     this.db = bdb.create(this.options)
     this.checkpoints = this.chain.options.checkpoints
     this.locker = new Lock()
+    this.bound = []
     if (options) this.fromOptions(options)
   }
 
@@ -87,6 +88,61 @@ class HeaderIndexer extends Indexer {
     await super.open()
     await this.initializeChain()
     this.logger.info('Indexer successfully loaded')
+  }
+
+  /**
+   * Close the indexer, wait for the database to close, and handleClose
+   * for removing event listeners
+   * @returns {void}
+   */
+  async close() {
+    await super.close()
+    return this.handleClose()
+  }
+
+  /**
+   * Unbind all events.
+   * @private
+   */
+
+  async handleClose() {
+    for (const [obj, event, listener] of this.bound) obj.removeListener(event, listener)
+
+    this.bound.length = 0
+  }
+
+  /**
+   * Bind to chain events.
+   * overwrites parent `bind` method to add to `bound` array
+   * for removal on close
+   * @private
+   */
+  bind() {
+    const listener = async (entry, block, view) => {
+      const meta = new BlockMeta(entry.hash, entry.height)
+
+      try {
+        await this.sync(meta, block, view)
+      } catch (e) {
+        this.emit('error', e)
+      }
+    }
+
+    this._bind(this.chain, 'connect', listener)
+    this._bind(this.chain, 'disconnect', listener)
+    this._bind(this.chain, 'reset', listener)
+  }
+
+  /**
+   * Bind to an event on `obj`, save listener for removal.
+   * @private
+   * @param {EventEmitter} obj
+   * @param {String} event
+   * @param {Function} listener
+   */
+  _bind(obj, event, listener) {
+    this.bound.push([obj, event, listener])
+    obj.on(event, listener)
   }
 
   /**


### PR DESCRIPTION
Added behavior for managing event listeners a bit more efficiently. I've submitted [a PR to bcoin](https://github.com/bcoin-org/bcoin/pull/789) for this fix but in the meantime, it's trivial to add it to our own custom indexer.